### PR TITLE
turning on drill fields for issue extended

### DIFF
--- a/issue_extended.view.lkml
+++ b/issue_extended.view.lkml
@@ -988,13 +988,13 @@ view: issue_extended {
 
   measure: count {
     type: count
-    drill_fields: [id, days_to_resolve_issue, created_date, severity ]
+    drill_fields: [detail*]
   }
 
   # ----- Sets of fields for drilling ------
-  #set: detail {
-  #  fields: [
-  #    external_issue_id,
-  #  ]
-  #}
+  set: detail {
+    fields: [
+      key, summary, description, status_name
+    ]
+  }
 }


### PR DESCRIPTION
As we will be using issue extended more, turning on the drill fields for exploring, currently including key (commonly recognized as their ID at the top of the card, for example, AD-308), summary (commonly recognized as their title/name), description, and status_name (Todo, In Progress, Done).

These fields are what I considered basic information for an issue, open to suggestions.