### PR TITLE
Thank you Fivetran for this amazing Jira block

### DIFF
--- a/issue_extended.view.lkml
+++ b/issue_extended.view.lkml
@@ -980,7 +980,7 @@ view: issue_extended {
     group_label: "Resolution"
     label: "Time to Resolve (Days)"
     type: number
-    sql: DATE_DIFF(${created_raw},${resolved_raw}, DAY) ;;
+    sql: DATE_DIFF(${created_date},${resolved_date}, DAY) ;;
     value_format_name: decimal_0
   }
 

--- a/issue_extended.view.lkml
+++ b/issue_extended.view.lkml
@@ -988,19 +988,19 @@ view: issue_extended {
   # ----- Measures ------
   measure: total_time_to_resolve_issues_hours {
     group_label: "Resolution"
-    label: "Total Time to Resolve Issues per Grouping"
+    label: "Total Hours to Resolve Issues per Grouping"
     description: "The total hours required to resolve all issues in the chosen dimension grouping"
     type: sum
-    sql: ${days_to_resolve_issue} ;;
+    sql: ${hours_to_resolve_issue};;
     value_format_name: decimal_0
   }
 
   measure: avg_time_to_resolve_issues_hours {
     group_label: "Resolution"
-    label: "Avg Time to Resolve Issues per Grouping"
+    label: "Avg Hours to Resolve Issues per Grouping"
     description: "The average hours required to resolve all issues in the chosen dimension grouping"
     type: average
-    sql: ${days_to_resolve_issue} ;;
+    sql: ${hours_to_resolve_issue} ;;
     value_format_name: decimal_0
   }
 

--- a/issue_extended.view.lkml
+++ b/issue_extended.view.lkml
@@ -964,7 +964,7 @@ view: issue_extended {
     group_label: "Resolution"
     label: "Time to Resolve (Hours)"
     type: number
-    sql: TIMESTAMP_DIFF(${created_raw}, ${resolved_raw}, HOUR) ;;
+    sql: TIMESTAMP_DIFF(${resolved_raw}, ${created_raw}, HOUR) ;;
     value_format_name: decimal_0
   }
 
@@ -972,7 +972,7 @@ view: issue_extended {
     group_label: "Resolution"
     label: "Time to Resolve (Minutes)"
     type: number
-    sql: TIMESTAMP_DIFF(${created_raw}, ${resolved_raw}, MINUTE) ;;
+    sql: TIMESTAMP_DIFF(${resolved_raw}, ${created_raw}, MINUTE) ;;
     value_format_name: decimal_0
   }
 
@@ -980,7 +980,7 @@ view: issue_extended {
     group_label: "Resolution"
     label: "Time to Resolve (Days)"
     type: number
-    sql: DATE_DIFF(${created_date},${resolved_date}, DAY) ;;
+    sql: DATE_DIFF(${resolved_date}, ${created_date}, DAY) ;;
     value_format_name: decimal_0
   }
 


### PR DESCRIPTION
fixing the time dimensions so they work. 

- DATE_DIFF was referencing timestamps
- They had the created date before the resolved date so time spent was negative. 
- Description said hours and the field being referenced was days