### PR TITLE
Distinct Jira measures and Drill Fields

### DIFF
--- a/bigquery/issue.view.lkml
+++ b/bigquery/issue.view.lkml
@@ -711,6 +711,7 @@ view: issue {
   measure: total_normalized_points {
     type: sum
     sql: ${points_normalized} ;;
+    drill_fields: [detail*, story_points, points_normalized]
   }
 
   measure: total_time_to_resolve_issues_hours {
@@ -720,6 +721,7 @@ view: issue {
     type: sum
     sql: ${hours_to_resolve_issue} ;;
     value_format_name: decimal_0
+    drill_fields: [detail*, hours_to_resolve_issue]
   }
 
   measure: avg_time_to_resolve_issues_hours {
@@ -729,6 +731,7 @@ view: issue {
     type: average
     sql: ${hours_to_resolve_issue} ;;
     value_format_name: decimal_0
+    drill_fields: [detail*, hours_to_resolve_issue]
   }
 
   measure: total_time_to_resolve_issues_days {
@@ -738,6 +741,7 @@ view: issue {
     type: sum
     sql: ${days_to_resolve_issue} ;;
     value_format_name: decimal_0
+    drill_fields: [detail*, days_to_resolve_issue]
   }
 
   measure: avg_time_to_resolve_issues_days {
@@ -747,12 +751,14 @@ view: issue {
     type: average
     sql: ${days_to_resolve_issue} ;;
     value_format_name: decimal_0
+    drill_fields: [detail*, days_to_resolve_issue]
   }
 
   measure: total_time_spent {
     label: "Time Spent in Seconds"
     type: sum
     sql: ${_time_spent} ;;
+    drill_fields: [detail*, _time_spent]
   }
 
   measure: total_hours_spent {
@@ -760,11 +766,13 @@ view: issue {
     type: sum
     value_format_name: decimal_0
     sql: ${_time_spent} / 3600 ;;
+    drill_fields: [detail*, _time_spent]
   }
 
   measure: total_story_points {
     type: sum
     sql: ${story_points} ;;
+    drill_fields: [detail*, story_points]
   }
 
   measure: total_story_points_closed_within_sprint {

--- a/models/issue_extended.view.lkml
+++ b/models/issue_extended.view.lkml
@@ -1202,6 +1202,7 @@ view: issue_extended {
     sql_distinct_key: ${key} ;;
     sql: ${hours_to_resolve_issue};;
     value_format_name: decimal_0
+    drill_fields: [points_detail*, hours_to_resolve_issue, created_time, resolved_time]
   }
 
   measure: avg_time_to_resolve_issues_hours {
@@ -1212,6 +1213,7 @@ view: issue_extended {
     sql_distinct_key: ${key} ;;
     sql: ${hours_to_resolve_issue} ;;
     value_format_name: decimal_0
+    drill_fields: [points_detail*, hours_to_resolve_issue, created_time, resolved_time]
   }
 
   measure: total_story_points {
@@ -1258,7 +1260,7 @@ view: issue_extended {
     sql_distinct_key: ${key} ;;
     sql: ${_time_spent}/3600 ;;
     value_format_name: decimal_0
-    drill_fields: [detail*]
+    drill_fields: [detail*, _time_spent]
   }
 
   measure: avg_issue_age {
@@ -1267,6 +1269,7 @@ view: issue_extended {
     sql_distinct_key: ${key} ;;
     value_format: "0"
     sql: DATE_DIFF(CURRENT_DATE(), ${created_date}, DAY) ;;
+    drill_fields: [points_detail*, created_date]
   }
 
   dimension: issue_age_group {

--- a/models/issue_extended.view.lkml
+++ b/models/issue_extended.view.lkml
@@ -1198,7 +1198,8 @@ view: issue_extended {
     group_label: "Resolution"
     label: "Total Hours to Resolve Issues per Grouping"
     description: "The total hours required to resolve all issues in the chosen dimension grouping"
-    type: sum
+    type: sum_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${hours_to_resolve_issue};;
     value_format_name: decimal_0
   }
@@ -1207,34 +1208,41 @@ view: issue_extended {
     group_label: "Resolution"
     label: "Avg Hours to Resolve Issues per Grouping"
     description: "The average hours required to resolve all issues in the chosen dimension grouping"
-    type: average
+    type: average_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${hours_to_resolve_issue} ;;
     value_format_name: decimal_0
   }
 
   measure: total_story_points {
-    type: sum
+    type: sum_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${story_points} ;;
+    drill_fields: [points_detail*]
   }
 
   measure: total_open_story_points {
     description: "To Do, Backlog, Parking Lot, In Progress, Code Review, Review. Excluding Duplicate, Rejected."
-    type: sum
+    type: sum_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${story_points} ;;
     filters: {
       field: status_name
       value:"To Do, Backlog, Parking Lot, In Progress, Code Review, Review"
     }
+    drill_fields: [points_detail*]
   }
 
   measure: total_closed_story_points {
     description: "Done, Sign Off. Excluding Duplicate, Rejected."
-    type: sum
+    type: sum_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${story_points} ;;
     filters: {
       field: status_name
       value:"Done, Sign Off"
     }
+    drill_fields: [points_detail*]
   }
 
   measure: count {
@@ -1246,7 +1254,8 @@ view: issue_extended {
   measure: total_time_spent {
     label: "Total time spent in hour"
     description: "Estimated total seconds spent on an issue. Typically only entered for 'Bug' and 'Task' type issues."
-    type: sum
+    type: sum_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${_time_spent}/3600 ;;
     value_format_name: decimal_0
     drill_fields: [detail*]
@@ -1254,7 +1263,8 @@ view: issue_extended {
 
   measure: avg_issue_age {
     label: "Average Issue Age (Days)"
-    type: average
+    type: average_distinct
+    sql_distinct_key: ${key} ;;
     value_format: "0"
     sql: DATE_DIFF(CURRENT_DATE(), ${created_date}, DAY) ;;
   }
@@ -1281,14 +1291,22 @@ view: issue_extended {
   }
 
   measure: total_normalized_points {
-    type: sum
+    type: sum_distinct
+    sql_distinct_key: ${key} ;;
     sql: ${points_normalized} ;;
+    drill_fields: [points_detail*, points_normalized]
   }
 
   # ----- Sets of fields for drilling ------
   set: detail {
     fields: [
       key, summary, status_name, priority_name, bug_priority_name, bug_severity_name, customer_name, updated_date
+    ]
+  }
+
+  set: points_detail {
+    fields: [
+      key, summary, status_name, story_points
     ]
   }
 }

--- a/models/issue_extended.view.lkml
+++ b/models/issue_extended.view.lkml
@@ -295,7 +295,6 @@ view: issue_extended {
   }
 
   dimension: id {
-    primary_key: yes
     type: number
     sql: ${TABLE}.id ;;
   }


### PR DESCRIPTION
The `issue_extended` view has fanout built into the PDT, so non-distinct measure don't behave as expected. Here I'm changing all the sums and averages to be distinct on `issue`